### PR TITLE
feat: show updated time in asset list

### DIFF
--- a/client/src/components/ChartWidget/TableWidget.svelte
+++ b/client/src/components/ChartWidget/TableWidget.svelte
@@ -1,5 +1,6 @@
 <script>
   import { onMount, createEventDispatcher } from 'svelte'
+  import dayjs from 'dayjs'
   import {
     Button,
     Card,
@@ -135,6 +136,11 @@
       typeSortOrder = 'none'
     }
   }
+
+  const getLatestUpdatedTime = (item) => {
+    const latestTime = item.updated || item.created || item.datetime
+    return latestTime ? dayjs(latestTime).format('YYYY-MM-DD HH:mm') : '--'
+  }
 </script>
 
 <Card
@@ -161,6 +167,7 @@
       </TableHeadCell>
       <TableHeadCell>{$_('amount')}</TableHeadCell>
       <TableHeadCell>{$_('currency')}</TableHeadCell>
+      <TableHeadCell>{$_('latestUpdatedTime')}</TableHeadCell>
       <TableBodyCell><span class="px-4 py-2">{$_('action')}</span></TableBodyCell>
       <TableBodyCell><span class="px-4 py-2">{$_('action')}</span></TableBodyCell>
     </TableHead>
@@ -176,6 +183,7 @@
             {item.amount}
           </TableBodyCell>
           <TableBodyCell>{getCurrencyName(item.currency) + ($language ? '' : '')}</TableBodyCell>
+          <TableBodyCell>{getLatestUpdatedTime(item)}</TableBodyCell>
           <TableBodyCell>
             <Button
               size="sm"
@@ -218,6 +226,7 @@
             {$targetCurrencyName}
           </strong>
         </TableBodyCell>
+        <TableBodyCell>--</TableBodyCell>
         <TableBodyCell>
           <Button size="sm" outline class="border-none focus:ring-0" on:click={onPersistClick}>
             <span class="text-mark hover:text-brand font-bold">{$_('persist')}</span>

--- a/client/src/lang/en.json
+++ b/client/src/lang/en.json
@@ -37,6 +37,7 @@
   "datetime": "Date",
   "remark": "Remark",
   "currency": "Currency",
+  "latestUpdatedTime": "Updated",
   "insightsNav": "Insights",
   "backToHomepage": "Back to Homepage",
   "high": "High",

--- a/client/src/lang/fr.json
+++ b/client/src/lang/fr.json
@@ -37,6 +37,7 @@
   "datetime": "Date",
   "remark": "Remarque",
   "currency": "Devise",
+  "latestUpdatedTime": "Mise a jour",
   "insightsNav": "Aperçus",
   "backToHomepage": "Retour à l'accueil",
   "high": "Élevé",

--- a/client/src/lang/ja.json
+++ b/client/src/lang/ja.json
@@ -37,6 +37,7 @@
   "datetime": "日付",
   "remark": "備考",
   "currency": "通貨",
+  "latestUpdatedTime": "更新日時",
   "insightsNav": "インサイト",
   "backToHomepage": "ホームページに戻る",
   "high": "高",

--- a/client/src/lang/zh-tw.json
+++ b/client/src/lang/zh-tw.json
@@ -37,6 +37,7 @@
   "datetime": "日期",
   "remark": "備註",
   "currency": "幣種",
+  "latestUpdatedTime": "更新時間",
   "insightsNav": "見解",
   "backToHomepage": "返回主頁",
   "high": "高",

--- a/client/src/lang/zh.json
+++ b/client/src/lang/zh.json
@@ -37,6 +37,7 @@
   "datetime": "日期",
   "remark": "备注",
   "currency": "币种",
+  "latestUpdatedTime": "更新时间",
   "insightsNav": "见解",
   "backToHomepage": "返回主页",
   "high": "高",

--- a/client/src/typings/index.d.ts
+++ b/client/src/typings/index.d.ts
@@ -21,6 +21,8 @@ export interface AssetsItem {
   datetime: string
   note: string
   tags?: string
+  created?: string
+  updated?: string
 }
 
 export interface Settings {


### PR DESCRIPTION
## Summary

- add an `Updated` column to the asset list on the homepage
- format the displayed timestamp on the client without changing backend APIs
- keep the implementation backward-compatible by falling back from `updated` to `created` to `datetime`
- shorten the column label to a compact table-friendly wording across locales

## Why

The asset list previously showed type, amount, and currency, but it did not tell users when a row was last changed. That made it harder to answer basic questions such as:

- which asset entry was updated most recently
- whether a displayed amount is current or stale
- whether a recent manual edit has already taken effect

This change solves that with a low-risk frontend-only update. The backend already returns the necessary time fields, so adding the column in the UI avoids API churn and keeps the scope minimal.

## Implementation Notes

- the new column is rendered in `client/src/components/ChartWidget/TableWidget.svelte`
- timestamp priority is:
  1. `updated`
  2. `created`
  3. `datetime`
- no server routes, controllers, or models were changed
- locale strings were added/updated for Chinese, Traditional Chinese, English, Japanese, and French
- the asset typing was extended so the frontend can consume `created` / `updated` safely

## Verification

- [x] `cd client && npm run build`

Build completed successfully. Existing repo warnings from Svelte/Tailwind remain, but this change does not introduce a new build failure.
